### PR TITLE
Fix ros active in S&B

### DIFF
--- a/Cell2Fire/FuelModelSpain.cpp
+++ b/Cell2Fire/FuelModelSpain.cpp
@@ -2366,19 +2366,11 @@ fire_type(inputs* data, main_outs* at)
 float
 rate_of_spread10(inputs* data, arguments* args)
 {
-    // FM 10 coef
-    float p1 = 0.2802, p2 = 0.07786, p3 = 0.01123;
-    float ros, ros10, ws, ffros, fcbd, fccf;
-
-    ffros = args->ROS10Factor;
-    fcbd = args->CBDFactor;
-    fccf = args->CCFFactor;
-
-    ws = data->ws;
-    ros10 = 1. / (p1 * exp(-p2 * ws * 0.4) + p3);
-
-    ros = ffros * ros10 + fccf * data->ccf + fcbd * data->cbd;
-
+    const float p1 = 0.2802;
+    const float p2 = 0.07786;
+    const float p3 = 0.01123;
+    float ros10 = 1. / (p1 * exp(-p2 * data->ws * 0.4) + p3);
+    float ros = args->ROS10Factor * ros10 + args->CCFFactor * data->ccf + args->CBDFactor * data->cbd;
     return (ros);
 }
 

--- a/Cell2Fire/FuelModelSpain.cpp
+++ b/Cell2Fire/FuelModelSpain.cpp
@@ -2377,7 +2377,7 @@ rate_of_spread10(inputs* data, arguments* args)
     ws = data->ws;
     ros10 = 1. / (p1 * exp(-p2 * ws * 0.4) + p3);
 
-    ros = ffros * ros10 + fccf * data->ccf + fcbd * args->CBDFactor;
+    ros = ffros * ros10 + fccf * data->ccf + fcbd * data->cbd;
 
     return (ros);
 }

--- a/Cell2Fire/FuelModelSpain.cpp
+++ b/Cell2Fire/FuelModelSpain.cpp
@@ -2369,8 +2369,15 @@ rate_of_spread10(inputs* data, arguments* args)
     const float p1 = 0.2802;
     const float p2 = 0.07786;
     const float p3 = 0.01123;
-    float ros10 = 1. / (p1 * exp(-p2 * data->ws * 0.4) + p3);
-    float ros = args->ROS10Factor * ros10 + args->CCFFactor * data->ccf + args->CBDFactor * data->cbd;
+    float ws = data->ws;
+    float ros10 = 1. / (p1 * exp(-p2 * ws * 0.4) + p3);
+
+    float ROS10Factor = args->ROS10Factor;
+    float CCFFactor = args->CCFFactor;
+    float CBDFactor = args->CBDFactor;
+    float ccf = data->ccf;
+    float cbd = data->cbd;
+    float ros = ROS10Factor * ros10 + CCFFactor * ccf + CBDFactor * cbd;
     return (ros);
 }
 


### PR DESCRIPTION
El ROS de copa ahora es calculado usando el CBD adecuadamente.
Al ejecutar la simulación con` --cros --CBDFactor <n>` al ROS de copa de cada celda debe sumarsele su CBD x CBDFactor. (n>0)