### PR TITLE
Move constants setup outside simulation

### DIFF
--- a/.github/workflows/build-debian-stable.yml
+++ b/.github/workflows/build-debian-stable.yml
@@ -1,4 +1,4 @@
-name: build debian stable
+name: build debian matrix
 
 on:
   pull_request:
@@ -13,7 +13,11 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: debian:stable-slim
+    strategy:
+      matrix:
+        debian_version: [bookworm, trixie]
+    name: build-${{ matrix.debian_version }}
+    container: debian:${{ matrix.debian_version }}-slim
 
     steps:
       - name: Checkout Code
@@ -57,7 +61,8 @@ jobs:
           DISTRIBUTION=$( lsb_release --short --id 2>/dev/null )
           CODENAME=$( lsb_release --short --codename 2>/dev/null )
           MACHINE=$( uname --machine 2>/dev/null )
-          echo "SUFFIX=".${DISTRIBUTION}.${CODENAME}.${MACHINE}"" >> $GITHUB_ENV
+          echo "SUFFIX=.${DISTRIBUTION}.${CODENAME}.${MACHINE}" >> $GITHUB_ENV
+          echo "Using suffix: .${DISTRIBUTION}.${CODENAME}.${MACHINE}"
 
       - name: Build
         run: |
@@ -78,7 +83,11 @@ jobs:
   test:
     needs: build
     runs-on: ubuntu-latest
-    container: debian:stable-slim
+    strategy:
+      matrix:
+        debian_version: [bookworm, trixie]
+    name: test-${{ matrix.debian_version }}
+    container: debian:${{ matrix.debian_version }}-slim
 
     steps:
       - name: Checkout Code

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -6,9 +6,19 @@ on:
   #     - main
   workflow_dispatch:
   workflow_call:
+    inputs:
+      enabled:
+        description: 'Enable the full Windows build (set false to upload placeholder)'
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: write
+
+env:
+  # True means perform actual Windows build; false means skip and upload placeholder
+  ENABLED: ${{ inputs.enabled }}
 
 jobs:
   windows_build:
@@ -18,7 +28,16 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v4
 
+    - name: Skip build (placeholder artifact)
+      if: env.ENABLED != 'true'
+      run: |
+        echo "Windows build disabled (ENABLED=${{ env.ENABLED }})"
+        mkdir binaries
+        echo "Windows build disabled" > binaries/WINDOWS_BUILD_WAS_DISABLED.txt
+      shell: bash
+
     - name: Bump version in header (Windows)
+      if: env.ENABLED == 'true'
       shell: pwsh
       run: |
         if ( "${{ github.event_name }}" -eq "pull_request" ){
@@ -40,6 +59,7 @@ jobs:
         Select-String 'C2FW_VERSION' $path
 
     - name: Cache Boost
+      if: env.ENABLED == 'true'
       id: cache-boost
       uses: actions/cache@v4
       with:
@@ -50,6 +70,7 @@ jobs:
           boost-${{ runner.os }}-
 
     - name: Cache Dirent
+      if: env.ENABLED == 'true'
       id: cache-dirent
       uses: actions/cache@v4
       with:
@@ -60,6 +81,7 @@ jobs:
           dirent-${{ runner.os }}-
 
     - name: Cache vcpkg
+      if: env.ENABLED == 'true'
       id: cache-vcpkg
       uses: actions/cache@v4
       with:
@@ -70,7 +92,7 @@ jobs:
           vcpkg-${{ runner.os }}-
 
     - name: Download dependencies
-      if: steps.cache-vcpkg.outputs.cache-hit != 'true' || steps.cache-boost.outputs.cache-hit != 'true' || steps.cache-dirent.outputs.cache-hit != 'true'
+      if: env.ENABLED == 'true' && (steps.cache-vcpkg.outputs.cache-hit != 'true' || steps.cache-boost.outputs.cache-hit != 'true' || steps.cache-dirent.outputs.cache-hit != 'true')
       env:
         CACHE_BOOST: ${{ steps.cache-boost.outputs.cache-hit }}
         CACHE_DIRENT: ${{ steps.cache-dirent.outputs.cache-hit }}
@@ -107,6 +129,7 @@ jobs:
         }
 
     - name: Setup vcpkg
+      if: env.ENABLED == 'true'
       run: |
         cd Cell2Fire\include\vcpkg
         .\bootstrap-vcpkg.bat
@@ -116,12 +139,14 @@ jobs:
         # Get-ChildItem -Recurse installed\x64-windows | ForEach-Object { $_.FullName }
 
     - name: Cache Catch2 header
+      if: env.ENABLED == 'true'
       uses: actions/cache@v4
       with:
         path: Cell2Fire\include\catch2\catch.hpp
         key: windows-catch2
 
     - name: Download Catch2 header
+      if: env.ENABLED == 'true'
       run: |
         cd Cell2Fire
         if (!(Test-Path "include\catch2\catch.hpp")) {
@@ -130,14 +155,17 @@ jobs:
         }
 
     - name: Setup MSBuild
+      if: env.ENABLED == 'true'
       uses: microsoft/setup-msbuild@v2
 
     - name: Build Solution
+      if: env.ENABLED == 'true'
       run: |
         cd Cell2Fire
         msbuild Cell2Fire.sln /p:Configuration=Release
 
     - name: Run Unit Tests
+      if: env.ENABLED == 'true'
       run: |
         & "Cell2Fire\x64\Release\WindowsTests.exe"
         $exitCode = $LASTEXITCODE
@@ -145,18 +173,20 @@ jobs:
       shell: pwsh
 
     - name: Run Regression Test
+      if: env.ENABLED == 'true'
       run: |
         cd test
         ./test.ps1
       shell: pwsh
 
     - name: Gather output
+      if: env.ENABLED == 'true'
       run: |
         mkdir binaries
         copy Cell2Fire\x64\Release\*.dll binaries
         copy Cell2Fire\x64\Release\Cell2Fire.exe binaries
 
-    - name: Upload
+    - name: Upload artifact (real or placeholder)
       uses: actions/upload-artifact@v4
       with:
         name: binaries-Windows-x86_64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,8 @@ jobs:
 
   build_windows:
       uses: ./.github/workflows/build-windows.yml
+      with:
+        enabled: true
 
   release:
     needs: [build_manylinux, build_windows, build_debian_stable, build_macos]
@@ -59,11 +61,16 @@ jobs:
       run: |
         cd Cell2Fire
         ls
-        zip ../Cell2FireW_${{ env.RELEASE_TAG }}-Windows-x86_64-binary.zip Cell2Fire.exe *.dll
-        zip ../Cell2FireW_${{ env.RELEASE_TAG }}-manylinux-x86_64-binary.zip Cell2Fire ldd_manylinux.txt
-        zip ../Cell2FireW_${{ env.RELEASE_TAG }}-Debian.bookworm.x86_64-binary.zip Cell2Fire.Debian.bookworm.x86_64 ldd.Debian.bookworm.x86_64.txt
-        zip ../Cell2FireW_${{ env.RELEASE_TAG }}-Ubuntu.noble.x86_64-binary.zip Cell2Fire.Ubuntu.noble.x86_64 ldd.Ubuntu.noble.x86_64.txt
-        zip ../Cell2FireW_${{ env.RELEASE_TAG }}-macOS-binaries.zip Cell2Fire_Darwin* otool*.txt
+        if [[ -f Cell2Fire.exe ]]; then
+          zip ../Cell2FireW_${RELEASE_TAG}-Windows-x86_64-binary.zip Cell2Fire.exe *.dll
+        else
+          zip ../Cell2FireW_${RELEASE_TAG}-Windows-x86_64-binary.zip WINDOWS_BUILD_WAS_DISABLED.txt
+        fi
+        zip ../Cell2FireW_${RELEASE_TAG}-manylinux-x86_64-binary.zip Cell2Fire ldd_manylinux.txt
+        zip ../Cell2FireW_${RELEASE_TAG}-Debian.bookworm.x86_64-binary.zip Cell2Fire.Debian.bookworm.x86_64 ldd.Debian.bookworm.x86_64.txt
+        zip ../Cell2FireW_${RELEASE_TAG}-Debian.trixie.x86_64-binary.zip Cell2Fire.Debian.trixie.x86_64 ldd.Debian.trixie.x86_64.txt
+        zip ../Cell2FireW_${RELEASE_TAG}-Ubuntu.noble.x86_64-binary.zip Cell2Fire.Ubuntu.noble.x86_64 ldd.Ubuntu.noble.x86_64.txt
+        zip ../Cell2FireW_${RELEASE_TAG}-macOS-binaries.zip Cell2Fire_Darwin* otool*.txt
 
     - name: Zip Data Instances
       run: |
@@ -94,6 +101,7 @@ jobs:
           Cell2FireW_${{ env.RELEASE_TAG }}-Windows-x86_64-binary.zip
           Cell2FireW_${{ env.RELEASE_TAG }}-manylinux-x86_64-binary.zip
           Cell2FireW_${{ env.RELEASE_TAG }}-Debian.bookworm.x86_64-binary.zip
+          Cell2FireW_${{ env.RELEASE_TAG }}-Debian.trixie.x86_64-binary.zip
           Cell2FireW_${{ env.RELEASE_TAG }}-Ubuntu.noble.x86_64-binary.zip
           Cell2FireW_${{ env.RELEASE_TAG }}-macOS-binaries.zip
           Kitral-asc.zip

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -1347,7 +1347,7 @@ Cell2Fire::SendMessages()
  * fire model.
  */
 void
-Cell2Fire::GetMessages(std::unordered_map<int, std::vector<int>> sendMessageList)
+Cell2Fire::GetMessages(const std::unordered_map<int, std::vector<int>>& sendMessageList)
 {
     // Iterator
     std::unordered_map<int, Cells>::iterator it;

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -2241,7 +2241,7 @@ Cell2Fire::getROSMatrix()
  * cell.
  */
 std::vector<float>
-Cell2Fire::getFireProgressMatrix()
+Cell2Fire::getFireProgressMatrix() const
 {
     std::vector<float> ProgressMatrix(this->nCells, 0);
     return ProgressMatrix;

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -2218,37 +2218,6 @@ Cell2Fire::Step(boost::random::mt19937 generator, int ep)
 }
 
 void
-Cell2Fire::InitHarvested()
-{
-    std::cout << "OK";
-}
-
-/**
- * @brief Retrieves the Rate of Spread (ROS) matrix for all cells.
- *
- * @return A vector of floats representing the ROS values for each cell.
- */
-std::vector<float>
-Cell2Fire::getROSMatrix()
-{
-    std::vector<float> ROSMatrix(this->nCells, 0);
-    return ROSMatrix;
-}
-
-/**
- * @brief Retrieves the Fire Progress matrix for all cells.
- *
- * @return A vector of floats representing the fire progress values for each
- * cell.
- */
-std::vector<float>
-Cell2Fire::getFireProgressMatrix()
-{
-    std::vector<float> ProgressMatrix(this->nCells, 0);
-    return ProgressMatrix;
-}
-
-void
 Cell2Fire::chooseWeather(const string& weatherOpt, int rnumber, int simExt)
 {
     string weatherFilename;

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -2354,7 +2354,18 @@ main(int argc, char* argv[])
     int num_threads = args.nthreads;
     Cell2Fire Forest2(args);  // generate Forest object
     std::vector<Cell2Fire> Forests(num_threads, Forest2);
-
+    if (args.Simulator == "K")
+    {
+        setup_const();
+    }
+    else if (args.Simulator == "S")
+    {
+        initialize_coeff(args.scenario);
+    }
+    else if (args.Simulator == "P")
+    {
+        initialize_coeff_p(args.scenario);
+    }
     cout << "\n-------Running simulations-------" << endl;
     // Parallel zone
 #pragma omp parallel num_threads(num_threads)

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -2242,7 +2242,7 @@ Cell2Fire::getROSMatrix()
  * cell.
  */
 std::vector<float>
-Cell2Fire::getFireProgressMatrix() const
+Cell2Fire::getFireProgressMatrix()
 {
     std::vector<float> ProgressMatrix(this->nCells, 0);
     return ProgressMatrix;

--- a/Cell2Fire/Cell2Fire.cpp
+++ b/Cell2Fire/Cell2Fire.cpp
@@ -11,6 +11,7 @@ __maintainer__ = "Jaime Carrasco, Cristobal Pais, David Woodruff, David Palacios
 #include "FuelModelKitral.h"
 #include "FuelModelPortugal.h"
 #include "FuelModelSpain.h"
+#include "FuelModelUtils.h"
 #include "Lightning.h"
 #include "ReadArgs.h"
 #include "ReadCSV.h"

--- a/Cell2Fire/Cell2Fire.h
+++ b/Cell2Fire/Cell2Fire.h
@@ -6,6 +6,7 @@
 #include "DataGenerator.h"
 #include "FuelModelKitral.h"
 #include "FuelModelSpain.h"
+#include "FuelModelUtils.h"
 #include "Lightning.h"
 #include "ReadArgs.h"
 #include "ReadCSV.h"

--- a/Cell2Fire/Cell2Fire.h
+++ b/Cell2Fire/Cell2Fire.h
@@ -136,7 +136,7 @@ class Cell2Fire
     void reset(int rnumber, double rnumber2, int simExt);
     bool RunIgnition(boost::random::mt19937 generator, int ep);
     std::unordered_map<int, std::vector<int>> SendMessages();
-    void GetMessages(std::unordered_map<int, std::vector<int>> sendMessageList);
+    void GetMessages(const std::unordered_map<int, std::vector<int>>& sendMessageList);
     void Results();
     void outputGrid();
     void updateWeather();

--- a/Cell2Fire/Cell2Fire.h
+++ b/Cell2Fire/Cell2Fire.h
@@ -146,7 +146,7 @@ class Cell2Fire
 
     // Utils
     std::vector<float> getROSMatrix();
-    std::vector<float> getFireProgressMatrix() const;
+    std::vector<float> getFireProgressMatrix();
     void chooseWeather(const string& weatherOpt, int rnumber, int simExt);
     int totalFirePeriods;
 };

--- a/Cell2Fire/Cell2Fire.h
+++ b/Cell2Fire/Cell2Fire.h
@@ -145,7 +145,7 @@ class Cell2Fire
 
     // Utils
     std::vector<float> getROSMatrix();
-    std::vector<float> getFireProgressMatrix();
+    std::vector<float> getFireProgressMatrix() const;
     void chooseWeather(const string& weatherOpt, int rnumber, int simExt);
     int totalFirePeriods;
 };

--- a/Cell2Fire/Cell2Fire.h
+++ b/Cell2Fire/Cell2Fire.h
@@ -142,11 +142,8 @@ class Cell2Fire
     void outputGrid();
     void updateWeather();
     void Step(boost::random::mt19937 generator, int ep);
-    void InitHarvested();
 
     // Utils
-    std::vector<float> getROSMatrix();
-    std::vector<float> getFireProgressMatrix();
     void chooseWeather(const string& weatherOpt, int rnumber, int simExt);
     int totalFirePeriods;
 };

--- a/Cell2Fire/Cell2Fire.vcxproj
+++ b/Cell2Fire/Cell2Fire.vcxproj
@@ -129,6 +129,7 @@
     <ClCompile Include="DataGenerator.cpp" />
     <ClCompile Include="Forest.cpp" />
     <ClCompile Include="FuelModelFBP.cpp" />
+    <ClCompile Include="FuelModelUtils.cpp" />
     <ClCompile Include="FuelModelKitral.cpp" />
     <ClCompile Include="FuelModelSpain.cpp" />
     <ClCompile Include="FuelModelPortugal.cpp" />
@@ -144,6 +145,7 @@
     <ClInclude Include="DataGenerator.h" />
     <ClInclude Include="Forest.h" />
     <ClInclude Include="FuelModelFBP.h" />
+    <ClCompile Include="FuelModelUtils.h" />
     <ClInclude Include="FuelModelKitral.h" />
     <ClInclude Include="FuelModelSpain.h" />
     <ClInclude Include="FuelModelPortugal.h" />

--- a/Cell2Fire/Cell2Fire.vcxproj
+++ b/Cell2Fire/Cell2Fire.vcxproj
@@ -129,10 +129,10 @@
     <ClCompile Include="DataGenerator.cpp" />
     <ClCompile Include="Forest.cpp" />
     <ClCompile Include="FuelModelFBP.cpp" />
-    <ClCompile Include="FuelModelUtils.cpp" />
     <ClCompile Include="FuelModelKitral.cpp" />
-    <ClCompile Include="FuelModelSpain.cpp" />
     <ClCompile Include="FuelModelPortugal.cpp" />
+    <ClCompile Include="FuelModelSpain.cpp" />
+    <ClCompile Include="FuelModelUtils.cpp" />
     <ClCompile Include="Lightning.cpp" />
     <ClCompile Include="ReadArgs.cpp" />
     <ClCompile Include="ReadCSV.cpp" />
@@ -145,10 +145,11 @@
     <ClInclude Include="DataGenerator.h" />
     <ClInclude Include="Forest.h" />
     <ClInclude Include="FuelModelFBP.h" />
-    <ClCompile Include="FuelModelUtils.h" />
     <ClInclude Include="FuelModelKitral.h" />
-    <ClInclude Include="FuelModelSpain.h" />
     <ClInclude Include="FuelModelPortugal.h" />
+    <ClInclude Include="FuelModelSpain.h" />
+    <ClInclude Include="FuelModelSpain.h" />
+    <ClInclude Include="FuelModelUtils.h" />
     <ClInclude Include="Lightning.h" />
     <ClInclude Include="ReadArgs.h" />
     <ClInclude Include="ReadCSV.h" />

--- a/Cell2Fire/Cell2Fire.vcxproj.filters
+++ b/Cell2Fire/Cell2Fire.vcxproj.filters
@@ -21,6 +21,9 @@
     <ClCompile Include="Forest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="FuelModelUtils.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="FuelModelKitral.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -60,6 +63,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Forest.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="FuelModelUtils.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="FuelModelKitral.h">

--- a/Cell2Fire/Cells.cpp
+++ b/Cell2Fire/Cells.cpp
@@ -483,11 +483,12 @@ Cells::manageFire(int period,
                     &flankstruct,
                     &backstruct,
                     activeCrown,
-                    nullptr);
+                    wdf_ptr);
     }
     else if (args->Simulator == "C")
     {
-        calculate_fbp(&df_ptr[this->realId - 1], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct);
+        calculate_fbp(
+            &df_ptr[this->realId - 1], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct, wdf_ptr);
     }
 
     else if (args->Simulator == "P")
@@ -500,7 +501,8 @@ Cells::manageFire(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    wdf_ptr);
     }
 
     /*  ROSs DEBUG!   */
@@ -658,15 +660,15 @@ Cells::manageFire(int period,
                 }
                 else if (args->Simulator == "S")
                 {
-                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, nullptr);
+                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, wdf_ptr);
                 }
                 else if (args->Simulator == "C")
                 {
-                    determine_destiny_metrics_fbp(&df_ptr[int(nb) - 1], coef, &metrics, &metrics2);
+                    determine_destiny_metrics_fbp(&df_ptr[int(nb) - 1], coef, &metrics, &metrics2, wdf_ptr);
                 }
                 else if (args->Simulator == "P")
                 {
-                    determine_destiny_metrics_p(&df_ptr[int(nb) - 1], coef, args, &metrics);
+                    determine_destiny_metrics_p(&df_ptr[int(nb) - 1], coef, args, &metrics, wdf_ptr);
                 }
                 crownState[this->realId - 1] = mainstruct.crown;
                 crownState[nb - 1] = metrics.crown;
@@ -831,12 +833,13 @@ Cells::manageFireBBO(int period,
                     &flankstruct,
                     &backstruct,
                     activeCrown,
-                    nullptr);
+                    wdf_ptr);
     }
 
     else if (args->Simulator == "C")
     {
-        calculate_fbp(&df_ptr[this->realId - 1], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct);
+        calculate_fbp(
+            &df_ptr[this->realId - 1], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct, wdf_ptr);
     }
     else if (args->Simulator == "P")
     {
@@ -848,7 +851,8 @@ Cells::manageFireBBO(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    wdf_ptr);
     }
 
     /*  ROSs DEBUG!   */
@@ -992,15 +996,15 @@ Cells::manageFireBBO(int period,
                 }
                 else if (args->Simulator == "S")
                 {
-                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, nullptr);
+                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, wdf_ptr);
                 }
                 else if (args->Simulator == "C")
                 {
-                    determine_destiny_metrics_fbp(&df_ptr[int(nb) - 1], coef, &metrics, &metrics2);
+                    determine_destiny_metrics_fbp(&df_ptr[int(nb) - 1], coef, &metrics, &metrics2, wdf_ptr);
                 }
                 else if (args->Simulator == "P")
                 {
-                    determine_destiny_metrics_p(&df_ptr[int(nb) - 1], coef, args, &metrics);
+                    determine_destiny_metrics_p(&df_ptr[int(nb) - 1], coef, args, &metrics, wdf_ptr);
                 }
                 crownState[this->realId - 1] = mainstruct.crown;
                 crownState[nb - 1] = metrics.crown;
@@ -1151,17 +1155,25 @@ Cells::get_burned(int period,
                     &flankstruct,
                     &backstruct,
                     activeCrown,
-                    nullptr);
+                    wdf_ptr);
     }
 
     else if (args->Simulator == "C")
     {
-        calculate_fbp(&df[this->id], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct);
+        calculate_fbp(&df[this->id], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct, wdf_ptr);
     }
     else if (args->Simulator == "P")
     {
-        calculate_p(
-            &(df[this->id]), coef, args, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct, activeCrown);
+        calculate_p(&(df[this->id]),
+                    coef,
+                    args,
+                    &mainstruct,
+                    &sndstruct,
+                    &headstruct,
+                    &flankstruct,
+                    &backstruct,
+                    activeCrown,
+                    wdf_ptr);
     }
 
     if (args->verbose)
@@ -1313,12 +1325,18 @@ Cells::ignition(int period,
                         &flankstruct,
                         &backstruct,
                         activeCrown,
-                        nullptr);
+                        wdf_ptr);
         }
         else if (args->Simulator == "C")
         {
-            calculate_fbp(
-                &df_ptr[this->realId - 1], coef, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct);
+            calculate_fbp(&df_ptr[this->realId - 1],
+                          coef,
+                          &mainstruct,
+                          &sndstruct,
+                          &headstruct,
+                          &flankstruct,
+                          &backstruct,
+                          wdf_ptr);
         }
         else if (args->Simulator == "P")
         {
@@ -1330,7 +1348,8 @@ Cells::ignition(int period,
                         &headstruct,
                         &flankstruct,
                         &backstruct,
-                        activeCrown);
+                        activeCrown,
+                        wdf_ptr);
         }
         if (args->verbose)
         {

--- a/Cell2Fire/Cells.cpp
+++ b/Cell2Fire/Cells.cpp
@@ -747,7 +747,7 @@ Cells::manageFire(int period,
 
     // If original is empty (no messages but fire is alive if aux_list is not
     // empty)
-    if (msg_list.size() == 0)
+    if (msg_list.empty())
     {
         if (msg_list_aux[0] == -100)
         {
@@ -1070,7 +1070,7 @@ Cells::manageFireBBO(int period,
 
     // If original is empty (no messages but fire is alive if aux_list is not
     // empty)
-    if (msg_list.size() == 0)
+    if (msg_list.empty())
     {
         if (msg_list_aux[0] == -100)
         {
@@ -1273,7 +1273,7 @@ Cells::ignition(int period,
 {
 
     // If we have ignition points, update
-    if (ignitionPoints.size() > 0)
+    if (!ignitionPoints.empty())
     {
         this->status = 1;
         this->fireStarts = period;

--- a/Cell2Fire/Cells.cpp
+++ b/Cell2Fire/Cells.cpp
@@ -442,14 +442,6 @@ Cells::manageFire(int period,
     msg_list_aux.push_back(0);
     std::vector<int> msg_list;
 
-    // Populate Inputs
-    df_ptr[this->realId - 1].waz = wdf_ptr->waz;
-    df_ptr[this->realId - 1].ws = wdf_ptr->ws;
-    df_ptr[this->realId - 1].tmp = wdf_ptr->tmp;
-    df_ptr[this->realId - 1].rh = wdf_ptr->rh;
-    df_ptr[this->realId - 1].bui = wdf_ptr->bui;
-    df_ptr[this->realId - 1].ffmc = wdf_ptr->ffmc;
-
     int head_cell = angleToNb[wdf_ptr->waz];  // head cell for slope calculation
     if (head_cell <= 0)                       // solve boundaries case
     {
@@ -477,7 +469,8 @@ Cells::manageFire(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    wdf_ptr);
     }
     else if (args->Simulator == "S")
     {
@@ -489,7 +482,8 @@ Cells::manageFire(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    nullptr);
     }
     else if (args->Simulator == "C")
     {
@@ -516,11 +510,8 @@ Cells::manageFire(int period,
         std::cout << "-------Input Structure--------" << std::endl;
         std::cout << "fueltype: " << df_ptr[this->realId - 1].fueltype << std::endl;
         std::cout << "nfueltype: " << df_ptr[this->realId - 1].nftype << std::endl;
-        std::cout << "ws: " << df_ptr[this->realId - 1].ws << std::endl;
-        std::cout << "waz: " << df_ptr[this->realId - 1].waz << std::endl;
+
         std::cout << "ps: " << df_ptr[this->realId - 1].ps << std::endl;
-        std::cout << "saz: " << df_ptr[this->realId - 1].saz << std::endl;
-        std::cout << "cur: " << df_ptr[this->realId - 1].cur << std::endl;
         std::cout << "elev: " << df_ptr[this->realId - 1].elev << std::endl;
         std::cout << "cbd: " << df_ptr[this->realId - 1].cbd << std::endl;
         std::cout << "cbh: " << df_ptr[this->realId - 1].cbh << std::endl;
@@ -661,19 +652,13 @@ Cells::manageFire(int period,
                 FSCell->push_back(double(nb));
                 FSCell->push_back(double(period));
                 FSCell->push_back(roundedRos);
-                df_ptr[nb - 1].waz = wdf_ptr->waz;
-                df_ptr[nb - 1].ws = wdf_ptr->ws;
-                df_ptr[nb - 1].tmp = wdf_ptr->tmp;
-                df_ptr[nb - 1].rh = wdf_ptr->rh;
-                df_ptr[nb - 1].bui = wdf_ptr->bui;
-                df_ptr[nb - 1].ffmc = wdf_ptr->ffmc;
                 if (args->Simulator == "K")
                 {
                     determine_destiny_metrics_k(&df_ptr[int(nb) - 1], coef, args, &metrics);
                 }
                 else if (args->Simulator == "S")
                 {
-                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics);
+                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, nullptr);
                 }
                 else if (args->Simulator == "C")
                 {
@@ -811,12 +796,6 @@ Cells::manageFireBBO(int period,
     fire_struc headstruct, backstruct, flankstruct, metrics2;
 
     // Populate inputs
-    df_ptr->waz = wdf_ptr->waz;
-    df_ptr->ws = wdf_ptr->ws;
-    df_ptr->bui = wdf_ptr->bui;
-    df_ptr->ffmc = wdf_ptr->ffmc;
-    df_ptr->tmp = wdf_ptr->tmp;
-    df_ptr->rh = wdf_ptr->rh;
     int head_cell = angleToNb[wdf_ptr->waz];  // head cell for slope calculation
     if (head_cell <= 0)                       // solve boundaries case
     {
@@ -838,7 +817,8 @@ Cells::manageFireBBO(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    wdf_ptr);
     }
     else if (args->Simulator == "S")
     {
@@ -850,7 +830,8 @@ Cells::manageFireBBO(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    nullptr);
     }
 
     else if (args->Simulator == "C")
@@ -876,8 +857,6 @@ Cells::manageFireBBO(int period,
         std::cout << "*********** ROSs debug ************" << std::endl;
         std::cout << "-------Input Structure--------" << std::endl;
         std::cout << "fueltype: " << df_ptr->fueltype << std::endl;
-        std::cout << "ws: " << df_ptr->ws << std::endl;
-        std::cout << "waz: " << df_ptr->waz << std::endl;
         std::cout << "ps: " << df_ptr->ps << std::endl;
         std::cout << "saz: " << df_ptr->saz << std::endl;
         std::cout << "cur: " << df_ptr->cur << std::endl;
@@ -1013,7 +992,7 @@ Cells::manageFireBBO(int period,
                 }
                 else if (args->Simulator == "S")
                 {
-                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics);
+                    determine_destiny_metrics_s(&df_ptr[int(nb) - 1], coef, args, &metrics, nullptr);
                 }
                 else if (args->Simulator == "C")
                 {
@@ -1138,10 +1117,6 @@ Cells::get_burned(int period,
     fire_struc headstruct, backstruct, flankstruct;
 
     // Compute main angle and ROSs: forward, flanks and back
-    df[this->id].waz = wdf_ptr->waz;
-    df[this->id].ws = wdf_ptr->ws;
-    df[this->id].tmp = wdf_ptr->tmp;
-    df[this->id].rh = wdf_ptr->rh;
     int head_cell = angleToNb[wdf_ptr->waz];  // head cell for slope calculation
     if (head_cell <= 0)                       // solve boundaries case
     {
@@ -1162,12 +1137,21 @@ Cells::get_burned(int period,
                     &headstruct,
                     &flankstruct,
                     &backstruct,
-                    activeCrown);
+                    activeCrown,
+                    wdf_ptr);
     }
     else if (args->Simulator == "S")
     {
-        calculate_s(
-            &(df[this->id]), coef, args, &mainstruct, &sndstruct, &headstruct, &flankstruct, &backstruct, activeCrown);
+        calculate_s(&(df[this->id]),
+                    coef,
+                    args,
+                    &mainstruct,
+                    &sndstruct,
+                    &headstruct,
+                    &flankstruct,
+                    &backstruct,
+                    activeCrown,
+                    nullptr);
     }
 
     else if (args->Simulator == "C")
@@ -1295,10 +1279,6 @@ Cells::ignition(int period,
         // << "  bui: " <<   wdf_ptr->bui << std::endl;
 
         // Populate inputs
-        df_ptr->waz = wdf_ptr->waz;
-        df_ptr->ws = wdf_ptr->ws;
-        df_ptr->bui = wdf_ptr->bui;
-        df_ptr->ffmc = wdf_ptr->ffmc;
         int head_cell = angleToNb[wdf_ptr->waz];  // head cell for slope calculation
         if (head_cell <= 0)                       // solve boundaries case
         {
@@ -1319,7 +1299,8 @@ Cells::ignition(int period,
                         &headstruct,
                         &flankstruct,
                         &backstruct,
-                        activeCrown);
+                        activeCrown,
+                        wdf_ptr);
         }
         else if (args->Simulator == "S")
         {
@@ -1331,7 +1312,8 @@ Cells::ignition(int period,
                         &headstruct,
                         &flankstruct,
                         &backstruct,
-                        activeCrown);
+                        activeCrown,
+                        nullptr);
         }
         else if (args->Simulator == "C")
         {

--- a/Cell2Fire/Cells.h
+++ b/Cell2Fire/Cells.h
@@ -3,7 +3,6 @@
 
 // include stuff
 #include "ReadArgs.h"
-
 #include <math.h>
 #include <stdio.h>
 #include <string>

--- a/Cell2Fire/Cells.h
+++ b/Cell2Fire/Cells.h
@@ -119,7 +119,7 @@ class Cells
                               int cols,
                               int rows);  // TODO: need TYPE
     void ros_distr_old(double thetafire, double forward, double flank, double back);
-    double rhoTheta(double theta, double a, double b);
+    static double rhoTheta(double theta, double a, double b);
     void ros_distr_V2(double thetafire, double a, double b, double c, double EFactor);
 
     std::vector<int> manageFire(int period,
@@ -197,8 +197,8 @@ class Cells
     void print_info();
 
   private:
-    double allocate(double offset, double base, double ros1, double ros2);
-    float slope_effect(float elev_i, float elev_j, int cellsize);
+    static double allocate(double offset, double base, double ros1, double ros2);
+    static float slope_effect(float elev_i, float elev_j, int cellsize);
 };
 
 #endif

--- a/Cell2Fire/FuelModelFBP.h
+++ b/Cell2Fire/FuelModelFBP.h
@@ -32,9 +32,9 @@ float bui_effect(fuel_coefs* ptr, main_outs* at, float bui);
 
 float ros_calc(inputs* inp, fuel_coefs* ptr, float isi, float* mu);
 
-float rate_of_spread(inputs* inp, fuel_coefs* ptr, main_outs* at);
+float rate_of_spread(inputs* inp, fuel_coefs* ptr, main_outs* at, weatherDF* wdf_ptr);
 
-float slope_effect(inputs* inp, fuel_coefs* ptr, main_outs* at, float isi);
+float slope_effect(inputs* inp, fuel_coefs* ptr, main_outs* at, float isi, weatherDF* wdf_ptr);
 
 float surf_fuel_consump(inputs* inp);
 
@@ -90,9 +90,16 @@ float flank_fire_behaviour(inputs* inp, fuel_coefs* ptr, main_outs* at, fire_str
 
 void set_all(fire_struc* ptr, int time);
 
-void calculate_fbp(
-    inputs* data, fuel_coefs* ptr, main_outs* at, snd_outs* sec, fire_struc* hptr, fire_struc* fptr, fire_struc* bptr);
-void determine_destiny_metrics_fbp(inputs* data, fuel_coefs* pt, main_outs* metrics, fire_struc* metrics2);
+void calculate_fbp(inputs* data,
+                   fuel_coefs* ptr,
+                   main_outs* at,
+                   snd_outs* sec,
+                   fire_struc* hptr,
+                   fire_struc* fptr,
+                   fire_struc* bptr,
+                   weatherDF* wdf_ptr);
+void determine_destiny_metrics_fbp(
+    inputs* data, fuel_coefs* pt, main_outs* metrics, fire_struc* metrics2, weatherDF* wdf_ptr);
 void zero_main(main_outs* m);
 
 void zero_sec(snd_outs* s);

--- a/Cell2Fire/FuelModelFBP.h
+++ b/Cell2Fire/FuelModelFBP.h
@@ -30,13 +30,13 @@ float conifer(fuel_coefs* ptr, float isi, float* mult);
 
 float bui_effect(fuel_coefs* ptr, main_outs* at, float bui);
 
-float ros_calc(inputs* inp, fuel_coefs* ptr, float isi, float* mu);
+float ros_calc(inputs* inp, fuel_coefs* ptr, float isi, float* mu, weatherDF* wdf_ptr);
 
 float rate_of_spread(inputs* inp, fuel_coefs* ptr, main_outs* at, weatherDF* wdf_ptr);
 
 float slope_effect(inputs* inp, fuel_coefs* ptr, main_outs* at, float isi, weatherDF* wdf_ptr);
 
-float surf_fuel_consump(inputs* inp);
+float surf_fuel_consump(inputs* inp, weatherDF* wdf_ptr);
 
 float fire_intensity(float fc, float ros);
 
@@ -66,7 +66,7 @@ float l_to_b(char ft[3], float ws);
 
 float ffmc_effect(float ffmc);
 
-float backfire_ros(inputs* inp, fuel_coefs* ptr, main_outs* at, float bisi);
+float backfire_ros(inputs* inp, fuel_coefs* ptr, main_outs* at, float bisi, weatherDF* wdf_ptr);
 
 float backfire_isi(main_outs* at);
 

--- a/Cell2Fire/FuelModelKitral.cpp
+++ b/Cell2Fire/FuelModelKitral.cpp
@@ -839,9 +839,6 @@ calculate_k(inputs* data,
             fire_struc* bptr,
             bool& activeCrown)
 {
-    // Hack: Initialize coefficients
-    setup_const();
-    setup_crown_const(data);
     // Aux
     float ros, bros, lb, fros;
     int FMC;

--- a/Cell2Fire/FuelModelKitral.cpp
+++ b/Cell2Fire/FuelModelKitral.cpp
@@ -989,7 +989,7 @@ void
 determine_destiny_metrics_k(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* metrics)
 {
     // Hack: Initialize coefficients
-    setup_const();
+    // setup_const();
     setup_crown_const(data);
 
     ptr->cbh = data->cbh;

--- a/Cell2Fire/FuelModelKitral.cpp
+++ b/Cell2Fire/FuelModelKitral.cpp
@@ -1,12 +1,9 @@
 #include "FuelModelKitral.h"
 #include "Cells.h"
+#include "FuelModelUtils.h"
 #include "ReadArgs.h"
 #include <cmath>
 #include <iostream>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -579,14 +576,14 @@ setup_crown_const(inputs* data)
 float
 rate_of_spread_k(inputs* data,
                  fuel_coefs* ptr,
-                 main_outs* at)  // incluir efecto pendiente aqui y no afuera
+                 main_outs* at,
+                 weatherDF* wdf_ptr)  // incluir efecto pendiente aqui y no afuera
 {
     float p1, p2, p3, ws, tmp, rh, ch, fmc, fch, fv, ps, fp;
-
     // se = slope_effect(inp) ;
-    ws = data->ws;
-    tmp = data->tmp;
-    rh = data->rh;
+    ws = wdf_ptr->ws;
+    tmp = wdf_ptr->tmp;
+    rh = wdf_ptr->rh;
     ps = at->se;  // hacerlo con elevaciones
     p1 = -12.86;
     p2 = 0.04316;
@@ -627,7 +624,7 @@ l_to_b(float ws, fuel_coefs* ptr)
     float l1, l2, lb;
     l1 = 2.233;     // 1.411; // ptr->l1 ;
     l2 = -0.01031;  // 0.01745; // ptr->l2 ;
-    lb = 1.0 + pow(l1 * exp(-l2 * ws) - l1, 2.0);
+    lb = 1 + pow(l1 * exp(-l2 * ws) - l1, 2.0);
     return lb;
 }
 
@@ -648,7 +645,7 @@ backfire_ros_k(main_outs* at, snd_outs* sec)
 
 // TODO: citation needed
 float
-slope_effect(float elev_i, float elev_j, int cellsize)
+slope_effect(const float elev_i, const float elev_j, const int cellsize)
 {
     float ps_ij = (elev_j - elev_i) / (cellsize / 4.);  // cellsize corresponds to the perimeter of the cell
     float se;
@@ -659,7 +656,7 @@ slope_effect(float elev_i, float elev_j, int cellsize)
 
 // TODO: citation needed
 float
-flame_length(inputs* data, main_outs* at)  // REVISAR ESTA ECUACI�N
+flame_length(main_outs* at)  // REVISAR ESTA ECUACI�N
 {
     float ib, fl;
 
@@ -667,29 +664,6 @@ flame_length(inputs* data, main_outs* at)  // REVISAR ESTA ECUACI�N
 
     fl = 0.0775 * pow(ib, 0.46);
     return fl;
-}
-
-// TODO: citation needed
-float
-angleFL(inputs* data, main_outs* at)
-{
-    float angle, fl, y, ws;
-    ws = data->ws;
-    fl = at->fl;
-    y = 10.0 / 36.0 * ws;
-
-    angle = atan(2.24 * sqrt(fl / pow(y, 2)));
-    return angle;
-}
-
-// TODO: citation needed
-float
-flame_height(inputs* data, main_outs* at)
-{
-    float fh, phi;
-    phi = angleFL(data, at);
-    fh = at->fl * sin(phi);
-    return fh;
 }
 
 // TODO: citation needed
@@ -747,15 +721,14 @@ crownfractionburn(inputs* data, main_outs* at, int FMC)
 
 // TODO: citation needed
 float
-active_rate_of_spreadPL04(inputs* data,
-                          main_outs* at)  // En KITRAL SE USA PL04
+active_rate_of_spreadPL04(inputs* data, main_outs* at, weatherDF* wdf_ptr)  // En KITRAL SE USA PL04
 {
     float p1, p2, p3, ws, tmp, rh, ch, fmc, fch, fv, ps, ros_active, rospl04, fp, ros_final, ros;
 
     // se = slope_effect(inp) ;
-    ws = data->ws;
-    tmp = data->tmp;
-    rh = data->rh;
+    ws = wdf_ptr->ws;
+    tmp = wdf_ptr->tmp;
+    rh = wdf_ptr->rh;
     ps = at->se;
     p1 = -12.86;
     p2 = 0.04316;
@@ -837,7 +810,8 @@ calculate_k(inputs* data,
             fire_struc* hptr,
             fire_struc* fptr,
             fire_struc* bptr,
-            bool& activeCrown)
+            bool& activeCrown,
+            weatherDF* wdf_ptr)
 {
     // Aux
     float ros, bros, lb, fros;
@@ -856,10 +830,7 @@ calculate_k(inputs* data,
     ptr->fmc = fmcs[data->nftype][0];
     ptr->cbh = data->cbh;
 
-    // cout << "   cbh " << ptr->cbh << "\n";
-
     ptr->fl = fls_david[data->nftype][0];
-    // cout << "   fl " << ptr->fl << "\n";
 
     ptr->h = hs[data->nftype][0];
     // cout << "   h " << ptr->h << "\n";
@@ -867,10 +838,11 @@ calculate_k(inputs* data,
     float elevation_destiny = head->elev;
     at->se = slope_effect(elevation_origin, elevation_destiny, cellsize);
     // Step 1: Calculate HROS (surface)
-    at->rss = rate_of_spread_k(data, ptr, at);
+    at->rss = rate_of_spread_k(data, ptr, at, wdf_ptr);
+
     hptr->rss = at->rss;
     // Step 2: Calculate Length-to-breadth
-    sec->lb = l_to_b(data->ws, ptr);
+    sec->lb = l_to_b(wdf_ptr->ws, ptr);
 
     // Step 3: Calculate BROS (surface)
     bptr->rss = backfire_ros_k(at, sec);
@@ -887,13 +859,13 @@ calculate_k(inputs* data,
     at->sfi = byram_intensity(data, at);
 
     // Step 7: Flame Length
-    at->fl = flame_length(data, at);
+    at->fl = flame_length(at);
 
     // Step 8: Flame angle
-    at->angle = angleFL(data, at);
+    at->angle = angleFL(wdf_ptr->ws, at);
 
     // Step 9: Flame Height
-    at->fh = flame_height(data, at);
+    at->fh = flame_height(at);
 
     // Step 10: Criterion for Crown Fire Initiation (no init if user does not
     // want to include it)
@@ -902,7 +874,7 @@ calculate_k(inputs* data,
         if (activeCrown)
         {
             // si el fuego esta activo en copas chequeamos condiciones
-            at->ros_active = active_rate_of_spreadPL04(data, at);
+            at->ros_active = active_rate_of_spreadPL04(data, at, wdf_ptr);
             if (!checkActive(data, at, FMC))
             {
                 activeCrown = false;
@@ -925,7 +897,7 @@ calculate_k(inputs* data,
     // If we have Crown fire, update the ROSs
     if (crownFire)
     {
-        at->ros_active = active_rate_of_spreadPL04(data, at);
+        at->ros_active = active_rate_of_spreadPL04(data, at, wdf_ptr);
         at->cfb = crownfractionburn(data, at, FMC);
 
         hptr->ros = final_rate_of_spreadPL04(at);
@@ -987,7 +959,7 @@ calculate_k(inputs* data,
     if (args->verbose)
     {
         cout << "--------------- Inputs --------------- \n";
-        cout << "ws = " << data->ws << "\n";
+
         cout << "coef data->cbh = " << data->cbh << "\n";
         cout << "coef ptr->fmc = " << ptr->fmc << "\n";
         cout << "coef ptr->cbh = " << ptr->cbh << "\n";
@@ -1033,7 +1005,7 @@ determine_destiny_metrics_k(inputs* data, fuel_coefs* ptr, arguments* args, main
     // Step 6: Byram Intensity
     metrics->sfi = byram_intensity(data, metrics);
     // Step 7: Flame Length
-    metrics->fl = flame_length(data, metrics);
+    metrics->fl = flame_length(metrics);
     // Step 10: Criterion for Crown Fire Initiation (no init if user does not
     // want to include it)
     if (args->AllowCROS && data->cbh > 0)

--- a/Cell2Fire/FuelModelKitral.cpp
+++ b/Cell2Fire/FuelModelKitral.cpp
@@ -631,7 +631,7 @@ l_to_b(float ws, fuel_coefs* ptr)
 /* ----------------- Back Rate of Spread --------------------------*/
 // TODO: citation needed
 float
-backfire_ros_k(main_outs* at, snd_outs* sec)
+backfire_ros_k(const main_outs* at, const snd_outs* sec)
 {
     float hb, bros, lb;
     // lb = l_to_b(data->fueltype,at->wsv) ;
@@ -656,7 +656,7 @@ slope_effect(const float elev_i, const float elev_j, const int cellsize)
 
 // TODO: citation needed
 float
-flame_length(main_outs* at)  // REVISAR ESTA ECUACI�N
+flame_length(const main_outs* at)  // REVISAR ESTA ECUACI�N
 {
     float ib, fl;
 

--- a/Cell2Fire/FuelModelKitral.cpp
+++ b/Cell2Fire/FuelModelKitral.cpp
@@ -624,7 +624,7 @@ l_to_b(float ws, fuel_coefs* ptr)
     float l1, l2, lb;
     l1 = 2.233;     // 1.411; // ptr->l1 ;
     l2 = -0.01031;  // 0.01745; // ptr->l2 ;
-    lb = 1 + pow(l1 * exp(-l2 * ws) - l1, 2.0);
+    lb = 1.0 + pow(l1 * exp(-l2 * ws) - l1, 2.0);
     return lb;
 }
 

--- a/Cell2Fire/FuelModelKitral.h
+++ b/Cell2Fire/FuelModelKitral.h
@@ -1,12 +1,9 @@
 #ifndef FUELMODELKITRAL
 #define FUELMODELKITRAL
 #include "Cells.h"
+#include "FuelModelUtils.h"
 #include "ReadArgs.h"
 #include <iostream>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -21,22 +18,16 @@ void setup_const();
 float flankfire_ros_k(float ros, float bros, float lb);
 
 // Calculate rate of spread
-float rate_of_spread_k(inputs* data, fuel_coefs* ptr, main_outs* at);
+float rate_of_spread_k(inputs* data, fuel_coefs* ptr, main_outs* at, weatherDF* wdf_ptr);
 
 // Length-to-Breadth ratio
 float l_to_b(float ws, fuel_coefs*);
 
 // BROS
-float backfire_ros_k(main_outs* at, snd_outs* sec);
+float backfire_ros_k(const main_outs* at, const snd_outs* sec);
 
 // Flame length [m])
-float flame_length(inputs* data, main_outs* at);
-
-// Angle of the flame w.r.t. horizontal surface (Putnam's)
-float angleFL(inputs* data, main_outs* at);
-
-// Transformation from FL to FH using angle
-float flame_height(inputs* data, main_outs* at);
+float flame_length(const main_outs* at);
 
 // byram intensity
 float byram_intensity(inputs* data, main_outs* at);
@@ -47,8 +38,7 @@ bool fire_type(inputs* data, main_outs* atr, int FMC);
 bool checkActive(inputs* data, main_outs* at, int FMC);
 // CROS adjustements
 float final_rate_of_spreadPL04(main_outs* at);
-float active_rate_of_spreadPL04(inputs* data,
-                                main_outs* at);  // En KITRAL SE USA PL04
+float active_rate_of_spreadPL04(inputs* data, main_outs* at, weatherDF* wdf_ptr);  // En KITRAL SE USA PL04
 float crownfractionburn(inputs* data, main_outs* at, int FMC);
 
 // Back fire with CROS
@@ -69,7 +59,8 @@ void calculate_k(inputs* data,
                  fire_struc* hptr,
                  fire_struc* fptr,
                  fire_struc* bptr,
-                 bool& activeCrown);
+                 bool& activeCrown,
+                 weatherDF* wdf_ptr);
 
 void determine_destiny_metrics_k(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* at);
 

--- a/Cell2Fire/FuelModelPortugal.cpp
+++ b/Cell2Fire/FuelModelPortugal.cpp
@@ -1,5 +1,6 @@
 #include "FuelModelPortugal.h"
 #include "Cells.h"
+#include "FuelModelUtils.h"
 #include "ReadArgs.h"
 #include <cmath>
 #include <iostream>
@@ -964,15 +965,14 @@ initialize_coeff_p(int scenario)
 }
 
 float
-rate_of_spread_p(inputs* data, fuel_coefs* ptr, main_outs* at)
+rate_of_spread_p(inputs* data, fuel_coefs* ptr, main_outs* at, float ws)
 {
-    float p1, p2, p3, ws;
+    float p1, p2, p3;
 
     p1 = p_coeff_p[data->nftype][0];
     p2 = p_coeff_p[data->nftype][1];
     p3 = p_coeff_p[data->nftype][2];
     // se = slope_effect(inp) ;
-    ws = data->ws;
     at->rss = 1.0 / (p1 * exp(-p2 * ws) + p3);
 
     return at->rss * (at->rss >= 0);
@@ -1013,11 +1013,9 @@ backfire_ros_p(main_outs* at, snd_outs* sec)
 }
 
 float
-flame_length_p(inputs* data, fuel_coefs* ptr)
+flame_length_p(inputs* data, fuel_coefs* ptr, float ws)
 {
-    float q1, q2, q3, fl, ws;
-
-    ws = data->ws;
+    float q1, q2, q3, fl;
     q1 = q_coeff_p[data->nftype][0];
     q2 = q_coeff_p[data->nftype][1];
     q3 = q_coeff_p[data->nftype][2];
@@ -1045,27 +1043,6 @@ crown_flame_length_p(float intensity)
     {
         return std::ceil(fl * 100.0) / 100.0;
     }
-}
-
-float
-angleFL_p(inputs* data, fuel_coefs* ptr)
-{
-    float angle, fl, y, ws;
-    ws = data->ws;
-    fl = flame_length_p(data, ptr);
-    y = 10.0 / 36.0 * ws;
-
-    angle = atan(2.24 * sqrt(fl / pow(y, 2)));
-    return angle;
-}
-
-float
-flame_height_p(inputs* data, fuel_coefs* ptr)
-{
-    float fh, phi;
-    phi = angleFL_p(data, ptr);
-    fh = flame_length_p(data, ptr) * sin(phi);
-    return fh;
 }
 
 float
@@ -1135,17 +1112,16 @@ fire_type_p(inputs* data, main_outs* at)
 }
 
 float
-rate_of_spread10_p(inputs* data, arguments* args)
+rate_of_spread10_p(inputs* data, arguments* args, float ws)
 {
     // FM 10 coef
     float p1 = 0.2802, p2 = 0.07786, p3 = 0.01123;
-    float ros, ros10, ws, ffros, fcbd, fccf;
+    float ros, ros10, ffros, fcbd, fccf;
 
     ffros = args->ROS10Factor;
     fcbd = args->CBDFactor;
     fccf = args->CCFFactor;
 
-    ws = data->ws;
     ros10 = 1. / (p1 * exp(-p2 * ws) + p3);
     ros = ffros * ros10 + fccf * data->ccf + fcbd * args->CBDFactor;
 
@@ -1232,7 +1208,8 @@ calculate_p(inputs* data,
             fire_struc* hptr,
             fire_struc* fptr,
             fire_struc* bptr,
-            bool& activeCrown)
+            bool& activeCrown,
+            weatherDF* wdf_ptr)
 {
 
     // Aux
@@ -1255,11 +1232,11 @@ calculate_p(inputs* data,
     ptr->nftype = data->nftype;
 
     // Step 1: Calculate HROS (surface)
-    at->rss = rate_of_spread_p(data, ptr, at);
+    at->rss = rate_of_spread_p(data, ptr, at, wdf_ptr->ws);
     hptr->rss = at->rss;
 
     // Step 2: Calculate Length-to-breadth
-    sec->lb = l_to_b_p(data->ws);
+    sec->lb = l_to_b_p(wdf_ptr->ws);
 
     // Step 3: Calculate BROS (surface)
     bptr->rss = backfire_ros_p(at, sec);
@@ -1273,15 +1250,15 @@ calculate_p(inputs* data,
     at->c = (hptr->rss - bptr->rss) / 2.;
 
     // Step 6: Flame Length
-    at->fl = flame_length_p(data, ptr);
+    at->fl = flame_length_p(data, ptr, wdf_ptr->ws);
 
     // std::cout << "hasta aqui todo bien" << std::endl;
 
     // Step 7: Flame angle
-    at->angle = angleFL_p(data, ptr);
+    at->angle = angleFL(wdf_ptr->ws, at);
 
     // Step 8: Flame Height
-    at->fh = flame_height_p(data, ptr);
+    at->fh = flame_height(at);
 
     // Step 9: Byram Intensity
     at->sfi = byram_intensity_p(at, ptr);
@@ -1291,7 +1268,7 @@ calculate_p(inputs* data,
     {
         if (activeCrown)
         {
-            at->ros_active = rate_of_spread10_p(data, args);
+            at->ros_active = rate_of_spread10_p(data, args, wdf_ptr->ws);
             if (!checkActive_p(data, at))
             {
                 activeCrown = false;
@@ -1315,7 +1292,7 @@ calculate_p(inputs* data,
     // If we have Crown fire, update the ROSs
     if (crownFire)
     {
-        at->ros_active = rate_of_spread10_p(data, args);
+        at->ros_active = rate_of_spread10_p(data, args, wdf_ptr->ws);
         at->cfb = crownfractionburn_p(data, at);
 
         hptr->ros = final_rate_of_spread10_p(data, at);
@@ -1411,7 +1388,7 @@ calculate_p(inputs* data,
 }
 
 void
-determine_destiny_metrics_p(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* metrics)
+determine_destiny_metrics_p(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* metrics, weatherDF* wdf_ptr)
 {
     // Hack: Initialize coefficients
     initialize_coeff_p(args->scenario);
@@ -1424,7 +1401,7 @@ determine_destiny_metrics_p(inputs* data, fuel_coefs* ptr, arguments* args, main
     ptr->q3 = q_coeff_p[data->nftype][2];
     ptr->nftype = data->nftype;
     // Step 6: Flame Length
-    metrics->fl = flame_length_p(data, ptr);
+    metrics->fl = flame_length_p(data, ptr, wdf_ptr->ws);
     // Step 9: Byram Intensity
     metrics->sfi = byram_intensity_p(metrics, ptr);
     // Set cfb value for no crown fire scenario

--- a/Cell2Fire/FuelModelPortugal.cpp
+++ b/Cell2Fire/FuelModelPortugal.cpp
@@ -1235,9 +1235,6 @@ calculate_p(inputs* data,
             bool& activeCrown)
 {
 
-    // Hack: Initialize coefficients
-    initialize_coeff_p(args->scenario);
-
     // Aux
     float ros, bros, lb, fros;
     bool crownFire = false;

--- a/Cell2Fire/FuelModelPortugal.h
+++ b/Cell2Fire/FuelModelPortugal.h
@@ -25,7 +25,7 @@ void initialize_coeff_p(int scenario);
 float flankfire_ros_p(float ros, float bros, float lb);
 
 // Calculate rate of spread
-float rate_of_spread_p(inputs* data, fuel_coefs* ptr, main_outs* at);
+float rate_of_spread_p(inputs* data, fuel_coefs* ptr, main_outs* at, float ws);
 
 // Length-to-Breadth ratio
 float l_to_b_p(float ws);
@@ -34,13 +34,7 @@ float l_to_b_p(float ws);
 float backfire_ros_p(main_outs* at, snd_outs* sec);
 
 // Flame length [m])
-float flame_length_p(inputs* data, fuel_coefs* ptr);
-
-// Angle of the flame w.r.t. horizontal surface (Putnam's)
-float angleFL_p(inputs* data, fuel_coefs* ptr);
-
-// Transformation from FL to FH using angle
-float flame_height_p(inputs* data, fuel_coefs* ptr);
+float flame_length_p(inputs* data, fuel_coefs* ptr, float ws);
 
 // byram intensity
 float byram_intensity_p(inputs* data, fuel_coefs* ptr);
@@ -49,7 +43,7 @@ float byram_intensity_p(inputs* data, fuel_coefs* ptr);
 bool fire_type_p(inputs* data, fuel_coefs* ptr);
 
 // CROS adjustements
-float rate_of_spread10_p(inputs* data, arguments* args);
+float rate_of_spread10_p(inputs* data, arguments* args, float ws);
 
 bool checkActive_p(inputs* data, main_outs* at);
 float crownfractionburn_p(inputs* data, main_outs* at);
@@ -69,8 +63,9 @@ void calculate_p(inputs* data,
                  fire_struc* hptr,
                  fire_struc* fptr,
                  fire_struc* bptr,
-                 bool& activeCrown);
+                 bool& activeCrown,
+                 weatherDF* wdf_ptr);
 
-void determine_destiny_metrics_p(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* at);
+void determine_destiny_metrics_p(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* at, weatherDF* wdf_ptr);
 
 #endif

--- a/Cell2Fire/FuelModelSpain.cpp
+++ b/Cell2Fire/FuelModelSpain.cpp
@@ -2475,8 +2475,6 @@ calculate_s(inputs* data,
             fire_struc* bptr,
             bool& activeCrown)
 {
-    // Hack: Initialize coefficients
-    initialize_coeff(args->scenario);
 
     // Aux
     float ros, bros, lb, fros;

--- a/Cell2Fire/FuelModelSpain.cpp
+++ b/Cell2Fire/FuelModelSpain.cpp
@@ -1,12 +1,9 @@
 #include "FuelModelSpain.h"
 #include "Cells.h"
+#include "FuelModelUtils.h"
 #include "ReadArgs.h"
 #include <cmath>
 #include <iostream>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -2194,15 +2191,14 @@ initialize_coeff(int scenario)
 
 // TODO: citation needed
 float
-rate_of_spread_s(inputs* data, fuel_coefs* ptr, main_outs* at)
+rate_of_spread_s(inputs* data, fuel_coefs* ptr, main_outs* at, float ws)
 {
-    float p1, p2, p3, ws;
+    float p1, p2, p3;
 
     p1 = p_coeff[data->nftype][0];
     p2 = p_coeff[data->nftype][1];
     p3 = p_coeff[data->nftype][2];
     // se = slope_effect(inp);
-    ws = data->ws;
     at->rss = 1.0 / (p1 * exp(-p2 * ws) + p3);
 
     return at->rss * (at->rss >= 0);
@@ -2245,11 +2241,10 @@ backfire_ros_s(main_outs* at, snd_outs* sec)
 
 // TODO: citation needed
 float
-flame_length(inputs* data, fuel_coefs* ptr)
+flame_length(inputs* data, fuel_coefs* ptr, float ws)
 {
-    float q1, q2, q3, fl, ws;
+    float q1, q2, q3, fl;
 
-    ws = data->ws;
     q1 = q_coeff[data->nftype][0];
     q2 = q_coeff[data->nftype][1];
     q3 = q_coeff[data->nftype][2];
@@ -2277,29 +2272,6 @@ crown_flame_length(float intensity)
     {
         return std::ceil(fl * 100.0) / 100.0;
     }
-}
-
-// TODO: citation needed
-float
-angleFL(inputs* data, fuel_coefs* ptr)
-{
-    float angle, fl, y, ws;
-    ws = data->ws;
-    fl = flame_length(data, ptr);
-    y = 10.0 / 36.0 * ws;
-
-    angle = atan(2.24 * sqrt(fl / pow(y, 2)));
-    return angle;
-}
-
-// TODO: citation needed
-float
-flame_height(inputs* data, fuel_coefs* ptr)
-{
-    float fh, phi;
-    phi = angleFL(data, ptr);
-    fh = flame_length(data, ptr) * sin(phi);
-    return fh;
 }
 
 // TODO: citation needed
@@ -2372,12 +2344,11 @@ fire_type(inputs* data, main_outs* at)
 
 // TODO: citation needed
 float
-rate_of_spread10(inputs* data, arguments* args)
+rate_of_spread10(inputs* data, arguments* args, float ws)
 {
     const float p1 = 0.2802;
     const float p2 = 0.07786;
     const float p3 = 0.01123;
-    float ws = data->ws;
     float ros10 = 1. / (p1 * exp(-p2 * ws * 0.4) + p3);
 
     float ROS10Factor = args->ROS10Factor;
@@ -2473,7 +2444,8 @@ calculate_s(inputs* data,
             fire_struc* hptr,
             fire_struc* fptr,
             fire_struc* bptr,
-            bool& activeCrown)
+            bool& activeCrown,
+            weatherDF* wdf_ptr)
 {
 
     // Aux
@@ -2496,11 +2468,11 @@ calculate_s(inputs* data,
     ptr->nftype = data->nftype;
 
     // Step 1: Calculate HROS (surface)
-    at->rss = rate_of_spread_s(data, ptr, at);
+    at->rss = rate_of_spread_s(data, ptr, at, wdf_ptr->ws);
     hptr->rss = at->rss;
 
     // Step 2: Calculate Length-to-breadth
-    sec->lb = l_to_b(data->ws);
+    sec->lb = l_to_b(wdf_ptr->ws);
 
     // Step 3: Calculate BROS (surface)
     bptr->rss = backfire_ros_s(at, sec);
@@ -2514,13 +2486,13 @@ calculate_s(inputs* data,
     at->c = (hptr->rss - bptr->rss) / 2.;
 
     // Step 6: Flame Length
-    at->fl = flame_length(data, ptr);
+    at->fl = flame_length(data, ptr, wdf_ptr->ws);
 
     // Step 7: Flame angle
-    at->angle = angleFL(data, ptr);
+    at->angle = angleFL(wdf_ptr->ws, at);
 
     // Step 8: Flame Height
-    at->fh = flame_height(data, ptr);
+    at->fh = flame_height(at);
 
     // Step 9: Byram Intensity
     at->sfi = byram_intensity(at, ptr);
@@ -2531,7 +2503,7 @@ calculate_s(inputs* data,
     {
         if (activeCrown)
         {
-            at->ros_active = rate_of_spread10(data, args);
+            at->ros_active = rate_of_spread10(data, args, wdf_ptr->ws);
             if (!checkActive(data, at))
             {
                 activeCrown = false;
@@ -2555,7 +2527,7 @@ calculate_s(inputs* data,
     // If we have Crown fire, update the ROSs
     if (crownFire)
     {
-        at->ros_active = rate_of_spread10(data, args);
+        at->ros_active = rate_of_spread10(data, args, wdf_ptr->ws);
         at->cfb = crownfractionburn(data, at);
 
         hptr->ros = final_rate_of_spread10(data, at);
@@ -2627,7 +2599,7 @@ calculate_s(inputs* data,
     if (args->verbose)
     {
         cout << "--------------- Inputs --------------- \n";
-        cout << "ws = " << data->ws << "\n";
+        cout << "ws = " << wdf_ptr->ws << "\n";
         cout << "coef data->cbh = " << data->cbh << "\n";
         cout << "coef ptr->p1 = " << ptr->p1 << "\n";
         cout << "coef ptr->p2 = " << ptr->p2 << "\n";
@@ -2654,7 +2626,7 @@ calculate_s(inputs* data,
 }
 
 void
-determine_destiny_metrics_s(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* metrics)
+determine_destiny_metrics_s(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* metrics, weatherDF* wdf_ptr)
 {
     // Hack: Initialize coefficients
     initialize_coeff(args->scenario);
@@ -2667,7 +2639,7 @@ determine_destiny_metrics_s(inputs* data, fuel_coefs* ptr, arguments* args, main
     ptr->q3 = q_coeff[data->nftype][2];
     ptr->nftype = data->nftype;
     // Step 6: Flame Length
-    metrics->fl = flame_length(data, ptr);
+    metrics->fl = flame_length(data, ptr, wdf_ptr->ws);
     // Step 9: Byram Intensity
     metrics->sfi = byram_intensity(metrics, ptr);
     // Set cfb value for no crown fire scenario

--- a/Cell2Fire/FuelModelSpain.h
+++ b/Cell2Fire/FuelModelSpain.h
@@ -1,12 +1,9 @@
 #ifndef FUELMODELSPAIN
 #define FUELMODELSPAIN
 #include "Cells.h"
+#include "FuelModelUtils.h"
 #include "ReadArgs.h"
 #include <iostream>
-#include <math.h>
-#include <stdio.h>
-#include <stdlib.h>
-#include <string.h>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -25,7 +22,7 @@ void initialize_coeff(int scenario);
 float flankfire_ros_s(float ros, float bros, float lb);
 
 // Calculate rate of spread
-float rate_of_spread_s(inputs* data, fuel_coefs* ptr, main_outs* at);
+float rate_of_spread_s(inputs* data, fuel_coefs* ptr, main_outs* at, float ws);
 
 // Length-to-Breadth ratio
 float l_to_b(float ws);
@@ -34,13 +31,7 @@ float l_to_b(float ws);
 float backfire_ros_s(main_outs* at, snd_outs* sec);
 
 // Flame length [m])
-float flame_length(inputs* data, fuel_coefs* ptr);
-
-// Angle of the flame w.r.t. horizontal surface (Putnam's)
-float angleFL(inputs* data, fuel_coefs* ptr);
-
-// Transformation from FL to FH using angle
-float flame_height(inputs* data, fuel_coefs* ptr);
+float flame_length(inputs* data, fuel_coefs* ptr, float ws);
 
 // byram intensity
 float byram_intensity(inputs* data, fuel_coefs* ptr);
@@ -49,7 +40,7 @@ float byram_intensity(inputs* data, fuel_coefs* ptr);
 bool fire_type(inputs* data, fuel_coefs* ptr);
 
 // CROS adjustements
-float rate_of_spread10(inputs* data, arguments* args);
+float rate_of_spread10(inputs* data, arguments* args, float ws);
 
 bool checkActive(inputs* data, main_outs* at);
 float crownfractionburn(inputs* data, main_outs* at);
@@ -70,8 +61,9 @@ void calculate_s(inputs* data,
                  fire_struc* hptr,
                  fire_struc* fptr,
                  fire_struc* bptr,
-                 bool& activeCrown);
+                 bool& activeCrown,
+                 weatherDF* wdf_ptr);
 
-void determine_destiny_metrics_s(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* at);
+void determine_destiny_metrics_s(inputs* data, fuel_coefs* ptr, arguments* args, main_outs* at, weatherDF* wdf_ptr);
 
 #endif

--- a/Cell2Fire/FuelModelUtils.cpp
+++ b/Cell2Fire/FuelModelUtils.cpp
@@ -1,0 +1,34 @@
+#include "FuelModelUtils.h"
+#include "Cells.h"
+#include "ReadArgs.h"
+#include <cmath>
+#include <iostream>
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+// Angle of the flame w.r.t. horizontal surface (Putnam's)
+float
+angleFL(const float ws, main_outs* at)
+{
+    float angle, fl, y;
+    fl = at->fl;
+    y = 10.0 / 36.0 * ws;
+
+    angle = atan(2.24 * sqrt(fl / pow(y, 2)));
+    return angle;
+}
+
+// Transformation from FL to FH using angle
+float
+flame_height(main_outs* at)
+{
+    float fh, phi;
+    phi = at->angle;
+    fh = at->fl * sin(phi);
+    return fh;
+}

--- a/Cell2Fire/FuelModelUtils.h
+++ b/Cell2Fire/FuelModelUtils.h
@@ -1,0 +1,19 @@
+//
+// Created by mati on 13-08-25.
+//
+
+#ifndef C2F_W_FUELMODELUTILS_H
+#define C2F_W_FUELMODELUTILS_H
+
+#include "Cells.h"
+#include <cmath>
+#include <iostream>
+#include <unordered_map>
+#include <vector>
+
+// Angle of the flame w.r.t. horizontal surface (Putnam's)
+float angleFL(const float ws, main_outs* at);
+
+// Transformation from FL to FH using angle
+float flame_height(main_outs* at);
+#endif  // C2F_W_FUELMODELUTILS_H

--- a/Cell2Fire/WindowsTests/WindowsTests.vcxproj
+++ b/Cell2Fire/WindowsTests/WindowsTests.vcxproj
@@ -110,7 +110,7 @@
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\Cell2Fire</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelKitral</AdditionalDependencies>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelKitral;$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelUtils</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -129,7 +129,7 @@
       <OptimizeReferences>true</OptimizeReferences>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(SolutionDir)\Cell2Fire</AdditionalLibraryDirectories>
-      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelKitral</AdditionalDependencies>
+      <AdditionalDependencies>$(CoreLibraryDependencies);%(AdditionalDependencies);$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelKitral;$(SolutionDir)Cell2Fire\$(Platform)\$(Configuration)\FuelModelUtils</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/Cell2Fire/makefile
+++ b/Cell2Fire/makefile
@@ -17,7 +17,7 @@ TEST_TARGET = test_cell2fire
 
 # Test source files
 TEST_DIR = ../test/unit_tests
-TEST_FILES = $(TEST_DIR)/*.cpp FuelModelKitral.cpp
+TEST_FILES = $(TEST_DIR)/*.cpp FuelModelKitral.cpp FuelModelUtils.cpp
 
 # Build rules
 all: $(TARGET)

--- a/Cell2Fire/makefile
+++ b/Cell2Fire/makefile
@@ -6,7 +6,7 @@ CXXFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_S
 LDFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_STD -lm -lpthread -ltiff
 
 # Source files
-SRCS = Cell2Fire.cpp Cells.cpp FuelModelSpain.cpp FuelModelPortugal.cpp FuelModelKitral.cpp FuelModelFBP.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
+SRCS = Cell2Fire.cpp Cells.cpp FuelModelUtils.cpp FuelModelSpain.cpp FuelModelPortugal.cpp FuelModelKitral.cpp FuelModelFBP.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
 
 # Object files
 OBJS = $(SRCS:.cpp=.o)

--- a/Cell2Fire/makefile.khipu
+++ b/Cell2Fire/makefile.khipu
@@ -5,13 +5,13 @@ CFLAGS = -std=c++14 -O3 -fopenmp
 LIBS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_STD -lm -lpthread -ldl
 TARGETS = Cell2Fire
 all:	$(TARGETS)
-Cell2Fire: Cell2Fire.o Cells.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o Lightning.o WriteCSV.o DataGenerator.o
-	$(CC) -o $@ $(LIBS) Cell2Fire.o Cells.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o Lightning.o WriteCSV.o DataGenerator.o
-Cell2Fire.o: Cell2Fire.cpp Cells.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o WriteCSV.o DataGenerator.o
+Cell2Fire: Cell2Fire.o Cells.o FuelModelUtils.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o Lightning.o WriteCSV.o DataGenerator.o
+	$(CC) -o $@ $(LIBS) Cell2Fire.o Cells.o FuelModelUtils.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o Lightning.o WriteCSV.o DataGenerator.o
+Cell2Fire.o: Cell2Fire.cpp Cells.o FuelModelUtils.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o Spotting.o ReadCSV.o ReadArgs.o WriteCSV.o DataGenerator.o
 	$(CC) -c $(CFLAGS) Cell2Fire.cpp
 Spotting.o: Spotting.cpp Spotting.h Cells.h
 	$(CC) -c $(CFLAGS) Spotting.cpp
-Cells.o: Cells.cpp Cells.h FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o
+Cells.o: Cells.cpp Cells.h FuelModelUtils.o FuelModelSpain.o FuelModelKitral.o FuelModelFBP.o FuelModelPortugal.o
 	$(CC) -c $(CFLAGS) Cells.cpp
 ReadCSV.o: ReadCSV.cpp ReadCSV.h 
 	$(CC) -c $(CFLAGS) ReadCSV.cpp
@@ -23,18 +23,20 @@ Forest.o: Forest.cpp Forest.h
 	$(CC) -c $(CFLAGS) Forest.cpp
 WriteCSV.o: WriteCSV.cpp WriteCSV.h
 	$(CC) -c $(CFLAGS) WriteCSV.cpp
-FuelModelSpain.o: FuelModelSpain.cpp FuelModelSpain.h Cells.h
+FuelModelUtils.o: FuelModelUtils.cpp FuelModelUtils.h Cells.h
+	$(CC) -c $(LIBS) $(CFLAGS) FuelModelUtils.cpp
+FuelModelSpain.o: FuelModelSpain.cpp FuelModelSpain.h FuelModelUtils.h Cells.h
 	$(CC) -c $(LIBS) $(CFLAGS) FuelModelSpain.cpp 
-FuelModelKitral.o: FuelModelKitral.cpp FuelModelKitral.h Cells.h
+FuelModelKitral.o: FuelModelKitral.cpp FuelModelUtils.h FuelModelKitral.h Cells.h
 	$(CC) -c $(LIBS) $(CFLAGS) FuelModelKitral.cpp 
 FuelModelFBP.o: FuelModelFBP.cpp FuelModelFBP.h Cells.h
 	$(CC) -c $(LIBS) $(CFLAGS) FuelModelFBP.cpp
-FuelModelPortugal.o: FuelModelPortugal.cpp FuelModelPortugal.h Cells.h
+FuelModelPortugal.o: FuelModelPortugal.cpp FuelModelUtils.h FuelModelPortugal.h Cells.h
 	$(CC) -c $(LIBS) $(CFLAGS) FuelModelPortugal.cpp
 DataGenerator.o: DataGenerator.cpp DataGenerator.h
 	$(CC) -c $(LIBS) $(CFLAGS) DataGenerator.cpp
 clean:
-	rm -f Lightning.o ReadArgs.o ReadCSV.o Cell2Fire.o Cells.o Cell2Fire Spotting.o WriteCSV.o FuelModelFBP.o FuelModelKitral.o FuelModelSpain.o FuelModelPortugal.o DataGenerator.o *.gch
+	rm -f Lightning.o ReadArgs.o ReadCSV.o Cell2Fire.o Cells.o Cell2Fire Spotting.o WriteCSV.o FuelModelFBP.o FuelModelKitral.o FuelModelSpain.o FuelModelPortugal.o FuelModelUtils.o DataGenerator.o *.gch
 	
 DESTDIR = ~/bin
 install: all

--- a/Cell2Fire/makefile.macos
+++ b/Cell2Fire/makefile.macos
@@ -24,7 +24,7 @@ CXXFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_S
 LDFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_STD -lm -lpthread -ltiff -L$(OPT)/libtiff/lib
 
 # Source files
-SRCS = Cell2Fire.cpp Cells.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
+SRCS = Cell2Fire.cpp Cells.cpp FuelModelUtils.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
 
 # Object files
 OBJS = $(SRCS:.cpp=.o)
@@ -35,7 +35,7 @@ TEST_TARGET = test_cell2fire
 
 # Test source files
 TEST_DIR = ../test/unit_tests
-TEST_FILES = $(TEST_DIR)/*.cpp FuelModelKitral.cpp
+TEST_FILES = $(TEST_DIR)/*.cpp FuelModelKitral.cpp FuelModelUtils.cpp
 
 # Build rules
 all: $(TARGET)

--- a/Cell2Fire/makefile.macos-static
+++ b/Cell2Fire/makefile.macos-static
@@ -29,7 +29,7 @@ LDFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_ST
           $(OPT)/zlib/lib/libz.a
 
 # Source files
-SRCS = Cell2Fire.cpp Cells.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
+SRCS = Cell2Fire.cpp Cells.cpp FuelModelUtils.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
 
 # Object files
 OBJS = $(SRCS:.cpp=.o)

--- a/Cell2Fire/makefile.static
+++ b/Cell2Fire/makefile.static
@@ -6,7 +6,7 @@ CXXFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_S
 LDFLAGS = -m64 -fPIC -fno-strict-aliasing -fexceptions -fopenmp -DNDEBUG -DIL_STD -static -static-libgcc -static-libstdc++ -lm -lpthread -ltiff -ljpeg -ljbig -llzma -lzstd -lwebp -ldeflate -lz -lLerc -lsharpyuv -Wl,--no-warn-search-mismatch
 
 # Source files
-SRCS = Cell2Fire.cpp Cells.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
+SRCS = Cell2Fire.cpp Cells.cpp FuelModelUtils.cpp FuelModelSpain.cpp FuelModelKitral.cpp FuelModelFBP.cpp FuelModelPortugal.cpp Spotting.cpp ReadCSV.cpp ReadArgs.cpp Lightning.cpp WriteCSV.cpp DataGenerator.cpp
 
 # Object files
 OBJS = $(SRCS:.cpp=.o)

--- a/test/unit_tests/test_kitral.cpp
+++ b/test/unit_tests/test_kitral.cpp
@@ -24,6 +24,7 @@ class NativeFuelFixture
     inputs* test_data;
     fuel_coefs* test_coefs;
     main_outs* test_outs;
+    weatherDF* wdf;
 
   public:
     NativeFuelFixture()
@@ -78,6 +79,11 @@ class NativeFuelFixture
         test_outs->crown = 0;
         test_outs->jd_min = 0;
         test_outs->jd = 0;
+
+        wdf->ws = 10;
+        wdf->waz = 45;
+        wdf->tmp = 27;
+        wdf->rh = 40;
     }
 };
 
@@ -92,27 +98,27 @@ TEST_CASE("Slope effect works correctly", "[slope_effect]")
 TEST_CASE_METHOD(NativeFuelFixture, "Rate of spread changes with slope", "[rate_of_spread_k]")
 {
     test_outs->se = 1;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(1.586, 0.001));
     test_outs->se = 0.5;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(1.463, 0.001));
     test_outs->se = 1.5;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(1.709, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Rate of spread changes with wind", "[rate_of_spread_k]")
 {
     test_outs->se = 1.2;
-    test_data->ws = 10;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    wdf->ws = 10;
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(1.635, 0.001));
-    test_data->ws = 50;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    wdf->ws = 50;
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(3.324, 0.001));
-    test_data->ws = 100;
-    rate_of_spread_k(test_data, test_coefs, test_outs);
+    wdf->ws = 100;
+    rate_of_spread_k(test_data, test_coefs, test_outs, wdf);
     REQUIRE_THAT(test_outs->rss, WithinAbs(3.648, 0.001));
 }
 
@@ -156,114 +162,114 @@ TEST_CASE_METHOD(NativeFuelFixture, "Test byram intensity", "[byram_intensity]")
 TEST_CASE_METHOD(NativeFuelFixture, "Test surface flame length", "[flame_length]")
 {
     test_outs->sfi = 16873.87;
-    REQUIRE_THAT(flame_length(test_data, test_outs), WithinAbs(6.82, 0.001));
+    REQUIRE_THAT(flame_length(test_outs), WithinAbs(6.82, 0.001));
     test_outs->sfi = 6299.58;
-    REQUIRE_THAT(flame_length(test_data, test_outs), WithinAbs(4.334, 0.001));
+    REQUIRE_THAT(flame_length(test_outs), WithinAbs(4.334, 0.001));
     test_outs->sfi = 40420;
-    REQUIRE_THAT(flame_length(test_data, test_outs), WithinAbs(10.193, 0.001));
+    REQUIRE_THAT(flame_length(test_outs), WithinAbs(10.193, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Test flame angle", "[angleFL]")
 {
-    test_data->ws = 10;
+    float ws = 10;
     test_outs->fl = 6.82;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(1.127, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(1.127, 0.001));
     test_outs->fl = 4.334;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(1.033, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(1.033, 0.001));
     test_outs->fl = 10.193;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(1.2, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(1.2, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Test flame angle changes with wind", "[angleFL]")
 {
-    test_data->ws = 100;
+    float ws = 100;
     test_outs->fl = 6.82;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(0.207, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(0.207, 0.001));
     test_outs->fl = 4.334;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(0.166, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(0.166, 0.001));
     test_outs->fl = 10.193;
-    REQUIRE_THAT(angleFL(test_data, test_outs), WithinAbs(0.251, 0.001));
+    REQUIRE_THAT(angleFL(ws, test_outs), WithinAbs(0.251, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Test flame height", "[flame_height]")
 {
-    test_data->ws = 10;
+    float ws = 10;
     test_outs->fl = 6.82;
-    REQUIRE_THAT(flame_height(test_data, test_outs), WithinAbs(6.160, 0.001));
+    REQUIRE_THAT(flame_height(ws, test_outs), WithinAbs(6.160, 0.001));
     test_outs->fl = 4.334;
-    REQUIRE_THAT(flame_height(test_data, test_outs), WithinAbs(3.723, 0.001));
+    REQUIRE_THAT(flame_height(ws, test_outs), WithinAbs(3.723, 0.001));
     test_outs->fl = 10.193;
-    REQUIRE_THAT(flame_height(test_data, test_outs), WithinAbs(9.501, 0.001));
+    REQUIRE_THAT(flame_height(ws, test_outs), WithinAbs(9.501, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Test flame height changes with wind", "[flame_height]")
 {
-    test_data->ws = 100;
+    float ws = 100;
     test_outs->fl = 6.82;
-    float fl_100 = flame_height(test_data, test_outs);
+    float fl_100 = flame_height(ws, test_outs);
     REQUIRE_THAT(fl_100, WithinAbs(1.405, 0.001));
-    test_data->ws = 50;
-    float fl_50 = flame_height(test_data, test_outs);
+    float ws = 50;
+    float fl_50 = flame_height(ws, test_outs);
     REQUIRE_THAT(fl_50, WithinAbs(2.647, 0.001));
     REQUIRE(fl_50 > fl_100);
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Active rate of spread changes with slope", "[active_rate_of_spreadPL04]")
 {
-    test_data->ws = 20;
-    test_data->tmp = 27;
-    test_data->rh = 40;
-    test_outs->se = 1;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(9.977, 0.001));
+    wdf->ws = 20;
+    wdf->tmp = 27;
+    wdf->rh = 40;
+    wdf->se = 1;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(9.977, 0.001));
     test_outs->se = 0.5;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(9.101, 0.001));
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(9.101, 0.001));
     test_outs->se = 1.8;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(11.378, 0.001));
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), wdf, WithinAbs(11.378, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Active rate of spread changes with wind", "[active_rate_of_spreadPL04]")
 {
     test_outs->se = 1.3;
-    test_data->tmp = 27;
-    test_data->rh = 40;
-    test_data->ws = 10;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(7.496, 0.001));
-    test_data->ws = 50;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(16.951, 0.001));
-    test_data->ws = 100;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(22.445, 0.001));
+    wdf->tmp = 27;
+    wdf->rh = 40;
+    wdf->ws = 10;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(7.496, 0.001));
+    wdf->ws = 50;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(16.951, 0.001));
+    wdf->ws = 100;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(22.445, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Active rate of spread changes with temperature", "[active_rate_of_spreadPL04]")
 {
-    test_data->ws = 20;
-    test_data->rh = 40;
+    wdf->ws = 20;
+    wdf->rh = 40;
     test_outs->se = 1.2;
-    test_data->tmp = -10;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(9.521, 0.001));
-    test_data->tmp = 0;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(9.728, 0.001));
-    test_data->tmp = 10;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(9.943, 0.001));
-    test_data->tmp = 20;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(10.166, 0.001));
-    test_data->tmp = 30;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(10.397, 0.001));
-    test_data->tmp = 40;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(10.637, 0.001));
+    wdf->tmp = -10;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(9.521, 0.001));
+    wdf->tmp = 0;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(9.728, 0.001));
+    wdf->tmp = 10;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(9.943, 0.001));
+    wdf->tmp = 20;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(10.166, 0.001));
+    wdf->tmp = 30;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(10.397, 0.001));
+    wdf->tmp = 40;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(10.637, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Active rate of spread changes with humidity", "[active_rate_of_spreadPL04]")
 {
-    test_data->ws = 20;
-    test_data->tmp = 26;
+    wdf->ws = 20;
+    wdf->tmp = 26;
     test_outs->se = 1.2;
-    test_data->rh = 5;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(115.518, 0.001));
+    wdf->rh = 5;
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(115.518, 0.001));
     test_data->rh = 25;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(36.817, 0.001));
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(36.817, 0.001));
     test_data->rh = 45;
-    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs), WithinAbs(7.823, 0.001));
+    REQUIRE_THAT(active_rate_of_spreadPL04(test_data, test_outs, wdf), WithinAbs(7.823, 0.001));
 }
 
 TEST_CASE_METHOD(NativeFuelFixture, "Test check for active fire", "[checkActive]")


### PR DESCRIPTION
Speeds up simulation time and lessens memory usage by setting up fuel model constants once per simulation batch